### PR TITLE
fix(setuptools): update pyproject setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "numpy", "cython>=0.29.28"]
+requires = ["setuptools==59.5.0", "numpy", "cython>=0.29.28"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Updates pyproject setuptools version. Bazel build was breaking without this update